### PR TITLE
update manual install instructions to shallow clone the git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ sudo zypper install cmake gcc-c++ extra-cmake-modules libQt5Gui-devel libQt5DBus
 ### Build and install
 
 ```
-git clone https://github.com/Luwx/Lightly.git
+git clone --single-branch --depth=1 https://github.com/Luwx/Lightly.git
 cd Lightly && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_TESTING=OFF ..
 make


### PR DESCRIPTION
It is unnecessary to clone the whole repo for install, shallow clone would be better as the size of this repo is  539.12 MB