### PR TITLE
Add an option to disable the thin separtor between the scrollbar

### DIFF
--- a/kstyle/config/lightlystyleconfig.cpp
+++ b/kstyle/config/lightlystyleconfig.cpp
@@ -47,6 +47,7 @@ namespace Lightly
 
         connect( _tabDrawHighlight, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _unifiedTabBarKonsole, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
+        connect( _renderThinSeperatorBetweenTheScrollBar, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _toolBarDrawItemSeparator, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _viewDrawFocusIndicator, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _dockWidgetDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
@@ -73,6 +74,7 @@ namespace Lightly
     {
         StyleConfigData::setTabDrawHighlight( _tabDrawHighlight->isChecked() );
         StyleConfigData::setUnifiedTabBarKonsole( _unifiedTabBarKonsole->isChecked() );
+        StyleConfigData::setRenderThinSeperatorBetweenTheScrollBar( _renderThinSeperatorBetweenTheScrollBar->isChecked() );
         StyleConfigData::setToolBarDrawItemSeparator( _toolBarDrawItemSeparator->isChecked() );
         StyleConfigData::setViewDrawFocusIndicator( _viewDrawFocusIndicator->isChecked() );
         StyleConfigData::setDockWidgetDrawFrame( _dockWidgetDrawFrame->isChecked() );
@@ -125,6 +127,7 @@ namespace Lightly
         // check if any value was modified
         if( _tabDrawHighlight->isChecked() != StyleConfigData::tabDrawHighlight() ) modified = true;
         else if( _unifiedTabBarKonsole->isChecked() != StyleConfigData::unifiedTabBarKonsole() ) modified = true;
+        else if( _renderThinSeperatorBetweenTheScrollBar->isChecked() != StyleConfigData::renderThinSeperatorBetweenTheScrollBar() ) modified = true;
         else if( _toolBarDrawItemSeparator->isChecked() != StyleConfigData::toolBarDrawItemSeparator() ) modified = true;
         else if( _viewDrawFocusIndicator->isChecked() != StyleConfigData::viewDrawFocusIndicator() ) modified = true;
         else if( _dockWidgetDrawFrame->isChecked() != StyleConfigData::dockWidgetDrawFrame() ) modified = true;
@@ -155,6 +158,7 @@ namespace Lightly
 
         _tabDrawHighlight->setChecked( StyleConfigData::tabDrawHighlight() );
         _unifiedTabBarKonsole->setChecked( StyleConfigData::unifiedTabBarKonsole() );
+        _renderThinSeperatorBetweenTheScrollBar->setChecked( StyleConfigData::renderThinSeperatorBetweenTheScrollBar() );
         _toolBarDrawItemSeparator->setChecked( StyleConfigData::toolBarDrawItemSeparator() );
         _viewDrawFocusIndicator->setChecked( StyleConfigData::viewDrawFocusIndicator() );
         _dockWidgetDrawFrame->setChecked( StyleConfigData::dockWidgetDrawFrame() );

--- a/kstyle/config/ui/lightlystyleconfig.ui
+++ b/kstyle/config/ui/lightlystyleconfig.ui
@@ -196,6 +196,13 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="1" colspan="4">
+        <widget class="QCheckBox" name="_renderThinSeperatorBetweenTheScrollBar">
+         <property name="text">
+          <string>Render a thin separator between the scrollbar</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">

--- a/kstyle/config/ui/lightlystyleconfig.ui
+++ b/kstyle/config/ui/lightlystyleconfig.ui
@@ -196,13 +196,6 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1" colspan="4">
-        <widget class="QCheckBox" name="_renderThinSeperatorBetweenTheScrollBar">
-         <property name="text">
-          <string>Render a thin separator between the scrollbar</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">
@@ -430,6 +423,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+        <item row="2" column="0">
+        <widget class="QCheckBox" name="_renderThinSeperatorBetweenTheScrollBar">
+         <property name="text">
+          <string>Render a thin separator between the scrollbar</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/kstyle/lightly.kcfg
+++ b/kstyle/lightly.kcfg
@@ -144,6 +144,10 @@
       <default>false</default>
     </entry>
 
+    <entry name="renderThinSeperatorBetweenTheScrollBar" type="Bool">
+      <default>true</default>
+    </entry>
+
     <!-- frames -->
     <entry name="TitleWidgetDrawFrame" type="Bool">
       <default>false</default>

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -7467,7 +7467,10 @@ namespace Lightly
                                         QSize(PenWidth::Frame, option->rect.height()), option->rect);
         }
 
-        _helper->renderScrollBarBorder( painter, separatorRect, _helper->alphaColor( option->palette.color( QPalette::Text ), 0.1 ));
+        if ( StyleConfigData::renderThinSeperatorBetweenTheScrollBar() ) {
+            _helper->renderScrollBarBorder( painter, separatorRect, _helper->alphaColor( option->palette.color( QPalette::Text ), 0.1 ));
+        }
+
 
         // render full groove directly, rather than using the addPage and subPage control element methods
         if( (!StyleConfigData::animationsEnabled() || mouseOver || animated) && option->subControls & SC_ScrollBarGroove )


### PR DESCRIPTION
I'm doing a reference to this Reddit post: 
https://reddit.com/r/kde/comments/loogpg/why_were_the_scrollbars_changed_to_have_its_own/

As it apparently caused bugs, according to the KDE team, before the behavior was changed, by default the behavior is the default KDE one (to show the thin separator), but since its always nice to give the user an option, they can turn it off if they wish :).
