### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Taken from https://github.com/n4n0GH/hello
 
 #### Ubuntu
 ```
-sudo apt install build-essential libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev libkf5iconthemes-dev gettext
+sudo apt install build-essential libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev
 ```
 
 #### Arch Linux


### PR DESCRIPTION
In some Debian distros some libraries of Qt are not totally installed, if 'make' instruction gives you some error while compiling (QPainter Class dependecies ) it is possible you need to install Qt libraries. 
Try with installing: sudo apt-get install qt3d5-dev