### PR TITLE
Add cmake to the list of dependencies on Ubuntu in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Taken from https://github.com/n4n0GH/hello
 
 #### Ubuntu
 ```
-sudo apt install build-essential libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev
+sudo apt install cmake build-essential libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev
 ```
 
 #### Arch Linux


### PR DESCRIPTION
Add cmake to the list of dependencies on Ubuntu. I recently tried manually installing this (wonderful!) theme and cmake was missing on my system after installing the dependencies.