### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Type "```a```" and press enter.
 
 ### Fedora
 ```
-sudo dnf install Lightly
+sudo dnf install lightly
 ```
 
 ### Fedora 32 RPM repository


### PR DESCRIPTION
`lightly` is the correct package name for fedora 36 repository