### PR TITLE
Register config module without keyword

### DIFF
--- a/kdecoration/lightlydecoration.cpp
+++ b/kdecoration/lightlydecoration.cpp
@@ -58,7 +58,7 @@ K_PLUGIN_FACTORY_WITH_JSON(
     "lightly.json",
     registerPlugin<Lightly::Decoration>();
     registerPlugin<Lightly::Button>();
-    registerPlugin<Lightly::ConfigWidget>(QStringLiteral("kcmodule"));
+    registerPlugin<Lightly::ConfigWidget>();
 )
 
 namespace


### PR DESCRIPTION
The plugin loading with keywords is both deprecated in KCoreAddons and KWin.
With KWin 5.25, the codepath was removed, meaning the KCM can no longer be loaded.

What I am unsure about is the policy of the repo in regards to the KWin version.
This change requires KWin 5.23 or greater, which should be widely available now.