### PR TITLE
fix(README): correct package name for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Type "```a```" and press enter.
 
 ### Fedora
 ```
-sudo dnf install Lightly
+sudo dnf install lightly
 ```
 
 ### Fedora 32 RPM repository


### PR DESCRIPTION
Corrects the package name for Fedora 37 from `sudo dnf install Lightly` to `sudo dnf install lightly` 