### PR TITLE
add essential dependencies for arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sudo apt install cmake build-essential libkf5config-dev libkdecorations2-dev lib
 
 #### Arch Linux
 ```
-sudo pacman -S cmake extra-cmake-modules kdecoration qt5-declarative qt5-x11extras
+sudo pacman -S cmake extra-cmake-modules kdecoration qt5-declarative qt5-x11extras libtool gcc gcc-libs
 ```
 
 #### Fedora


### PR DESCRIPTION
- I'm using Manjaro, The installation failed with the error `/usr/bin/ld: /usr/lib/libQt5Qml.so.5`.
- I've tried to uninstall but it also gives an error (unfortunately, I didn't save that)
- I tried to open KDE settings but it crashed, I used the command `systemsettings` to know what was wrong with it, it was something like this:  `missing /usr/lib/libstdc++.so.6 required by GLIBCXX_3.4.32 in /usr/lib/libQt5Qml.so.5`
- I'm sorry for not saving the exact errors. It's not that different
- after rebooting the laptop SDDM does not open and the problem is solved by using tty to install libtool, gcc and gcc-libs
- I hope this helps solve the issue for arch users